### PR TITLE
check_license: ignore pin_order.cfg files

### DIFF
--- a/base_checks/check_license.py
+++ b/base_checks/check_license.py
@@ -29,7 +29,7 @@ _spdx_license_header = 'SPDX-License-Identifier'
 IGNORED_DIRS = ['third_party', '.git']
 
 # Files ignored for license check
-IGNORED_FILES = ['LICENSE']
+IGNORED_FILES = ['LICENSE', 'pin_order.cfg']
 
 # File extensions to be ignored for license check
 IGNORED_EXTS = ['.def', '.gds', '.lef', '.mag']

--- a/base_checks/check_license.py
+++ b/base_checks/check_license.py
@@ -32,7 +32,7 @@ IGNORED_DIRS = ['third_party', '.git']
 IGNORED_FILES = ['LICENSE']
 
 # File extensions to be ignored for license check
-IGNORED_EXTS = ['.def', '.gds', '.lef', '.mag', '*.cfg']
+IGNORED_EXTS = ['.def', '.gds', '.lef', '.mag', '.cfg']
 
 
 def check_license(user_license_path, licenses_path):

--- a/base_checks/check_license.py
+++ b/base_checks/check_license.py
@@ -29,10 +29,10 @@ _spdx_license_header = 'SPDX-License-Identifier'
 IGNORED_DIRS = ['third_party', '.git']
 
 # Files ignored for license check
-IGNORED_FILES = ['LICENSE', 'pin_order.cfg']
+IGNORED_FILES = ['LICENSE']
 
 # File extensions to be ignored for license check
-IGNORED_EXTS = ['.def', '.gds', '.lef', '.mag']
+IGNORED_EXTS = ['.def', '.gds', '.lef', '.mag', '*.cfg']
 
 
 def check_license(user_license_path, licenses_path):


### PR DESCRIPTION
Comments are not (yet) allowed in .cfg file for pin order.  Just ignore
them from license checking