### PR TITLE
Added magic drc report to RDB conversion

### DIFF
--- a/drc_checks/magic_drc_to_rdb.py
+++ b/drc_checks/magic_drc_to_rdb.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import re
+import shutil
+import argparse
+import math
+
+
+def formatter(prog): return argparse.HelpFormatter(prog, max_help_position=60)
+
+
+parser = argparse.ArgumentParser(formatter_class=formatter)
+
+# Mandatory arguments
+parser.add_argument('--magic_drc_in', type=str, default="./checks/caravel.magic.drc")
+parser.add_argument('--rdb_out', type=str, default="./checks/caravel.magic.rdb")
+args = parser.parse_args()
+
+data, drc = True, False
+def main():
+    try:
+        fp = open(args.magic_drc_in)
+        lineType = data
+        drcRule = ""
+        with open(args.rdb_out,"w") as fpw:
+            for indx, line in enumerate(fp.readlines()):
+                if ("[INFO]" in line) or (len(line.strip())==0):
+                    continue
+                elif indx == 0:
+                    fpw.write(f"${line} 100\n")
+                elif "------" in line:
+                    lineType = not lineType
+                elif (lineType==drc):
+                    drcRule = line.strip().split("(")
+                    drcRule = [drcRule,"UnknownRule"] if len(drcRule) <2 else drcRule
+                    fpw.write(f"r_0_{drcRule[1][:-1]}\n")
+                    fpw.write(f"500 500 2 Nov 29 03:26:39 2020\n")
+                    fpw.write(f"Rule File Pathname: {args.magic_drc_in}\n")
+                    fpw.write(f"{drcRule[1][:-1]}: {drcRule[0]}\n")
+                    drcNumber = 1
+                elif (lineType==data):
+                    cord = [int(float(i))*100 for i in line.strip().split(" ")]
+                    fpw.write(f"p {drcNumber} 4\n")
+                    fpw.write(f"{cord[0]} {cord[1]}\n")
+                    fpw.write(f"{cord[2]} {cord[1]}\n")
+                    fpw.write(f"{cord[2]} {cord[3]}\n")
+                    fpw.write(f"{cord[0]} {cord[3]}\n")
+                    drcNumber+=1
+        print(f"Generated RDB at {args.rdb_out}")
+    except IOError:
+        print("Magic DRC Error file not found {args.magic_drc_in}")
+    except:
+        print("Failed to generate RDB file")
+    finally:
+        fp.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/drc_checks/run_drc_checks.sh
+++ b/drc_checks/run_drc_checks.sh
@@ -51,5 +51,12 @@ echo $Test_Magic_violations
 
 if [ 0 -ne $Test_Magic_violations ]; then echo "DRC Check FAILED"; exit -1; fi
 
+if [ 0 -ne $Test_Magic_violations ]; then
+    python3 $SCRIPTS_ROOT/magic_drc_to_rdb.py \
+        -magic_drc_in $OUT_DIR/$DESIGN_NAME.magic.drc \
+        -rdb_out $OUT_DIR/$DESIGN_NAME.magic.rdb
+fi
+echo "[Info] Converted errors in RDB format"
+
 echo "DRC Check Passed"
 exit 0


### PR DESCRIPTION
**Description**
This pull adds a simple python script to convert the saved magic drc report to rdb format. 
So it can be opened with Klayout or Synopsys RVE for debug.

 **Note**
- It creates a pseudo rdb format with some placeholder test to make report readable by Klayout of SNPS tool 