### PR TITLE
Dockerhub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,23 @@
 
 ## Setup:
 
-To setup the necessary docker file, run:
+### Docker:
+
+You can either build the docker locally or fetch it from dockerhub.
+#### Build Docker Locally
+To build the necessary docker locally, run:
 ```bash
     cd dependencies
     sh build-docker.sh
 ```
 
+#### Pull Docker from Dockerhub
+To pull the necessary docker from [dockerhub](https://hub.docker.com/repository/docker/efabless/open_mpw_precheck/tags?page=1&ordering=last_updated), run:
+```bash
+    docker pull efabless/open_mpw_precheck:latest
+```
+
+### PDK
 If you don't have the skywater-pdk installed, run:
 ```bash 
     export PDK_ROOT=<absolute path to where skywater-pdk and open_pdks will reside>
@@ -78,7 +89,7 @@ export PDK_ROOT=<The place where you want to install the pdk>
 docker run -it -v $(pwd):/usr/local/bin \
     -v $PDK_ROOT:$PDK_ROOT
     -u $(id -u $USER):$(id -g $USER) \
-    open_mpw_prechecker:latest
+    efabless/open_mpw_prechecker:latest
 ```
 Run the following command:
 

--- a/dependencies/build-docker.sh
+++ b/dependencies/build-docker.sh
@@ -14,5 +14,5 @@
 
 mkdir -p logs/docker
 echo "dir created"
-docker build --rm -t open_mpw_prechecker . | tee logs/docker/open_mpw_prechecker.build.txt
+docker build --rm -t efabless/open_mpw_prechecker:latest . | tee logs/docker/open_mpw_prechecker.build.txt
 

--- a/dependencies/build-pdk.sh
+++ b/dependencies/build-pdk.sh
@@ -15,7 +15,7 @@
 
 # exit when any command fails
 export RUN_ROOT=$(pwd)
-export IMAGE_NAME=open_mpw_prechecker:latest
+export IMAGE_NAME=efabless/open_mpw_prechecker:latest
 echo $PDK_ROOT
 echo $RUN_ROOT
 make skywater-pdk


### PR DESCRIPTION
- Renamed the docker image to `efabless/open_mpw_prechecker:latest` to allow for easier Dockerhub support.
- Added documentation on how to use and pull the pre-built dockerhub image.