### PR TITLE
check_defaults: Have a default return case for README

### DIFF
--- a/base_checks/check_defaults.py
+++ b/base_checks/check_defaults.py
@@ -42,6 +42,7 @@ def has_default_README():
                     return (True, "README.md has not been changed")
     except FileNotFoundError as notFound:
         return (True, "Could not open file %s"%notFound.filename)
+    return (failed, errors)
 
 def has_default_project_config():
     errors = ""


### PR DESCRIPTION
Otherwise the return from the function is NoneType

Signed-off-by: Konrad Rzeszutek Wilk <konrad@kernel.org>