### PR TITLE
has_default_content: Skip directories

### DIFF
--- a/base_checks/check_defaults.py
+++ b/base_checks/check_defaults.py
@@ -103,6 +103,8 @@ def has_default_content(lc):
                     adefault_file = Path(adefault_file)
                     if excluded(adefault_file) or excluded(anupdated_file):
                         continue
+                    if adefault_file.is_dir() or anupdated_file.is_dir():
+                        continue
                     with open(adefault_file, 'rb') as default, \
                         open(anupdated_file, 'rb') as updated:
                         if too_similar(str(default.read()), str(updated.read())):


### PR DESCRIPTION
The open(xx) does not work on directories and ends up
throwing an exception:

Traceback (most recent call last):
  File "open_mpw_prechecker.py", line 303, in <module>
    run_check_sequence(target_path, caravel_root, pdk_root, output_directory, run_fuzzy_checks, run_gds_fc, skip_drc, skip_xor, drc_only, dont_compress, manifest_source, run_klayout_drc, run_klayout_fom_density_check, private)
  File "open_mpw_prechecker.py", line 149, in run_check_sequence
    default_content, reason = check_defaults.has_default_content(lc)
  File "/usr/local/bin/base_checks/check_defaults.py", line 107, in has_default_content
    continue
IsADirectoryError: [Errno 21] Is a directory: '/home/konrad/caravel_user_project/verilog/rtl/sha1'

Signed-off-by: Konrad Rzeszutek Wilk <konrad@kernel.org>